### PR TITLE
Create knot-thing-simulator docker environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+venv/
+hooks/
+.gitignore
+Makefile
+.pre-commit-config.yaml
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# set base image (host OS)
+FROM python:3.8-slim
+
+# set the working directory in the container
+WORKDIR /usr/src/app
+
+# copy the dependencies file to the working directory
+COPY requirements.txt .
+
+# install dependencies
+RUN pip install -r requirements.txt
+
+# copy the content of the local src directory to the working directory
+COPY / .
+
+# command to run on container start
+EXPOSE 502/tcp
+CMD python3 ./knot-thing-simulator.py

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,8 @@
+FROM python:3.8-slim
+
+WORKDIR /usr/src/app
+
+COPY ./requirements.txt ./
+RUN pip install -r requirements.txt
+
+CMD ["python3", "./knot-thing-simulator.py"]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,59 @@ From the root dir run:
 sudo env PYTHONPATH=. python <file>
 ```
 
+### Docker Installation and Usage
+
+#### Pre-requisites
+
+To install the **project's Docker installation pre-requisites**, please follow the instructions in the link below:
+
+- [Docker](https://docs.docker.com/get-docker/)
+
+> _**Note**: if you're using a Linux system, please take a look at [Docker's post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/)!_
+
+#### Building and running
+
+Once you have all pre-requisites installed, change your current working directory to the project's root:
+
+```bash
+# change current working directory
+$ cd <path/to/knot-thing-simulator>
+```
+
+##### Development
+
+In order to build the **Docker development image**, use the command below:
+
+```bash
+# build docker image from Dockerfile-dev
+$ docker build . --file Dockerfile-dev --tag knot-thing-simulator:dev
+```
+
+Finally, run the **development** container with the following command:
+
+```bash
+# start the container and clean up upon exit.
+$ docker run --rm --publish 502:502 --volume `pwd`:/usr/src/app --tty --interactive knot-thing-simulator:dev
+```
+
+>**_Note_**: the `--volume` flag binds and mounts `pwd` (your current working directory) to the container's `/usr/src/app` directory. This means that the changes you make outside the container will be reflected inside (and vice-versa). You may use your IDE to make code modifications, additions, deletions and so on, and these changes will be persisted both in and outside the container.
+
+##### Production
+
+In order to build the **Docker production image**, use the command below:
+
+```bash
+# build docker image from Dockerfile
+$ docker build . --file Dockerfile --tag knot-thing-simulator
+```
+
+Finally, run the **production** container with the following command:
+
+```bash
+# start the container and clean up upon exit.
+$ docker run --rm --publish 502:502 --volume `pwd`:/usr/src/app --tty --interactive knot-thing-simulator
+```
+
 ## Configure the simulator
 The simulator provides an easy configuration template (config/config.json).
 In order to create a data server model of industrial things you need to follow the config template, where the fields are explained bellow:


### PR DESCRIPTION
Changes:
- Adds the dockerfiles and .dockerignore files. This files allow the user to set a thing-simulator as a
docker environment.
- Adds the thing-simulator's docker environment's initialization documentation into the README.md.